### PR TITLE
Fix issue with types export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,5 @@
 import { GraphQLScalarType } from 'graphql';
 
-class BigInt extends GraphQLScalarType {
+export default class BigInt extends GraphQLScalarType {
   constructor(mode: string)
 }
-
-export default BigInt;


### PR DESCRIPTION
Fixes an error:
error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

Sorry, I should have tested this before.