### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,13 +25,19 @@ export default class GraphQLBigInt extends GraphQLScalarType {
 			if (value === "") {
 				throw new TypeError("The value cannot be converted from BigInt because it is empty string");
 			}
-			if (typeof value !== "number" && typeof value !== "bigint") {
+			if (typeof value !== "number" && typeof value !== "bigint" && typeof value !== "string") {
 				throw new TypeError(
 					`The value ${value} cannot be converted to a BigInt because it is not an integer`
 				);
 			}
 
-			return global.BigInt(value);
+			try {
+				return global.BigInt(value);
+			} catch {
+				throw new TypeError(
+					`The value ${value} cannot be converted to a BigInt because it is not an integer`
+				);
+			}
 		};
 
 		const serializeBigIntValue = function(value) {


### PR DESCRIPTION
The new native BigInt datatype supports parsing from a string type.  I added string as an allowable type before attempting to parse, then wrapping the parsing with a try/catch in case the string is invalid.  I did this because while my API now supports BigInt with this library, the front-end portion connecting to the API does not and sends the value as a string.